### PR TITLE
Fix .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,7 @@ language: ruby
 bundler_args: --without development
 before_install: rm Gemfile.lock || true
 rvm:
-  - 2.0.0
+  - 2.3
 script: bundle exec rake test
 env:
-  - PUPPET_VERSION="~> 3.0"
   - PUPPET_VERSION="~> 4.0"

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,21 +3,8 @@ language: ruby
 bundler_args: --without development
 before_install: rm Gemfile.lock || true
 rvm:
-  - 1.8.7
-  - 1.9.3
   - 2.0.0
 script: bundle exec rake test
 env:
-  - PUPPET_VERSION="~> 2.7.0"
-  - PUPPET_VERSION="~> 3.1.0"
-  - PUPPET_VERSION="~> 3.2.0"
-  - PUPPET_VERSION="~> 3.3.0"
-  - PUPPET_VERSION="~> 3.4.0"
-matrix:
-  exclude:
-  - rvm: 2.0.0
-    env: PUPPET_VERSION="~> 2.7.0"
-  - rvm: 2.0.0
-    env: PUPPET_VERSION="~> 3.1.0"
-  - rvm: 1.9.3
-    env: PUPPET_VERSION="~> 2.7.0"
+  - PUPPET_VERSION="~> 3.0"
+  - PUPPET_VERSION="~> 4.0"


### PR DESCRIPTION
This reworks #9 opened by @petems 

* Use rvm ruby 2.3, as Arch currently has 2.3.3 (and Beaker requires >= 2.2.5)
* Only test puppet 4, as Arch currently has 4.8.0